### PR TITLE
chore: remove explicit google.golang.org/genproto replace directive

### DIFF
--- a/sql-kratos/go.mod
+++ b/sql-kratos/go.mod
@@ -4,8 +4,6 @@ go 1.24
 
 toolchain go1.24.4
 
-replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20250603155806-513f23925822
-
 require (
 	github.com/jinzhu/inflection v1.0.0
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
- Root Cause
```text
Go 禁止 go install ...@version 安装带有 replace 的远程模块，是为了保证依赖一致性和安全性：

如果远程模块的 go.mod 里有 replace，它会强制替换某些依赖版本，这可能与你本地项目的依赖冲突，导致不可预期的行为。
Go 设计的初衷是：只有你的主项目（main module）可以控制依赖替换，第三方库不应该影响你的依赖解析。
这样可以防止“依赖污染”，保证所有人安装到的依赖都是官方发布的、可验证的版本。
``` 

- Solution
This resolves 'go install' errors in dependent modules that reference this project by removing the pinned genproto version which was causing dependency conflicts."

