### PR TITLE
sql2orm 工具（v0.1.0）存在 Bug：mysqlProvider 和 postgresProvider 中有 defer db…

### DIFF
--- a/sql-orm/internal/ent/mux/provider.go
+++ b/sql-orm/internal/ent/mux/provider.go
@@ -22,7 +22,6 @@ func mysqlProvider(dsn string) (*ImportDriver, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
 
 	drv, err := atlasmysql.Open(db)
 	if err != nil {
@@ -48,7 +47,6 @@ func postgresProvider(dsn string) (*ImportDriver, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
 
 	drv, err := postgres.Open(db)
 	if err != nil {


### PR DESCRIPTION
….Close() 导致函数返回时数据库连接立即关闭，后续 InspectSchema 报 "database is closed" 错误。